### PR TITLE
Add markdown

### DIFF
--- a/mytemplates/templatetags/bbcode.py
+++ b/mytemplates/templatetags/bbcode.py
@@ -1,6 +1,6 @@
 from django import template
 
-from utils import bbcode
+from utils import bbcode, markdown
 
 register = template.Library()
 
@@ -15,4 +15,6 @@ class BBCodeNode(template.Node):
 		self.code = code
 	def render(self, context):
 		code = self.code.render(context).strip()
+		if code.startswith("[md]"):
+			return markdown.evaluate(code[4:])
 		return bbcode.evaluate(code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Django==3.0.8
 django-impersonate==1.5.1
 postmarkup==1.2.2
 Pygments==2.6.1
+Markdown==3.3.4
+mypy-extensions==0.4.3

--- a/templates/base.html
+++ b/templates/base.html
@@ -148,14 +148,17 @@
 		{% endblock %}
 
 		<script>
-			MathJax = {
+			window.MathJax = {
 			  tex: {
 				inlineMath: [['\\(','\\)']],
+				displayMath: [['\\[','\\]']],
 				autoload: {
 				  color: [],
 				  colorV2: ['color']
 				},
-				packages: {'[+]': ['noerrors']}
+				packages: {'[+]': ['noerrors']},
+				processEscapes: true,
+				processEnvironments: true
 			  },
 			  options: {
 				ignoreHtmlClass: 'tex2jax_ignore',

--- a/utils/markdown.py
+++ b/utils/markdown.py
@@ -1,0 +1,45 @@
+from markdown import markdown
+from pymdownx import emoji
+
+extensions = [
+    "markdown.extensions.tables",
+    "pymdownx.magiclink",
+    "pymdownx.betterem",
+    "pymdownx.tilde",
+    "pymdownx.emoji",
+    "pymdownx.tasklist",
+    "pymdownx.superfences",
+    "pymdownx.saneheaders",
+    "pymdownx.arithmatex",
+]
+
+extension_configs = {
+    "pymdownx.magiclink": {
+        "repo_url_shortener": True,
+        "repo_url_shorthand": True,
+        "provider": "github",
+        "user": "facelessuser",
+        "repo": "pymdown-extensions",
+    },
+    "pymdownx.tilde": {"subscript": False},
+    "pymdownx.emoji": {
+        "emoji_index": emoji.gemoji,
+        "emoji_generator": emoji.to_png,
+        "alt": "short",
+        "options": {
+            "attributes": {"align": "absmiddle", "height": "20px", "width": "20px"},
+            "image_path": "https://github.githubassets.com/images/icons/emoji/unicode/",
+            "non_standard_image_path": "https://gitfhub.githubassets.com/images/icons/emoji/",
+        },
+    },
+    "pymdownx.arithmatex": {"generic": True},
+    "pymdownx.superfences": {"css_class": "code"},
+}
+
+
+def evaluate(text):
+    return (
+        '<div class="markdown bbcode">'
+        + markdown(text, extensions=extensions, extension_configs=extension_configs)
+        + "</div>"
+    )


### PR DESCRIPTION
Adds Markdown support to BBCode tag.

In order to use Markdown, start the text with `[md]`. The rest will render as Markdown instead of BBcode.