### PR TITLE
Add markdown

### DIFF
--- a/help/urls.py
+++ b/help/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
 	url(r'^bbcode/$', views.bbcode, name='help-bbcode'),
 	url(r'^latex/$', views.latex, name='help-latex'),
 	url(r'^difficulty/$', views.difficulty, name='help-difficulty'),
+	url(r'^markdown/$', views.markdown, name='help-markdown'),
 	url(r'^$', views.help, name='help-help'),
 ]

--- a/help/views.py
+++ b/help/views.py
@@ -49,3 +49,7 @@ def bbcode(request):
 		"[list=A]\n[*] One\n[*] Two\n[*]Three\n[/list]",
 	)
 	return render(request, 'help/bbcode.html', {'bbcode_list' : lista, 'tab': 'bbcode' })
+
+@login_required
+def markdown(request):
+	return render(request, 'help/markdown.html', {'tab': 'markdown'})

--- a/mytemplates/templatetags/bbcode.py
+++ b/mytemplates/templatetags/bbcode.py
@@ -1,6 +1,6 @@
 from django import template
 
-from utils import bbcode
+from utils import bbcode, markdown
 
 register = template.Library()
 
@@ -15,4 +15,6 @@ class BBCodeNode(template.Node):
 		self.code = code
 	def render(self, context):
 		code = self.code.render(context).strip()
+		if code.startswith("[md]"):
+			return markdown.evaluate(code[4:])
 		return bbcode.evaluate(code)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytz==2021.1
 sqlparse==0.4.1
 typing-extensions==3.10.0.0
 zipp==3.5.0
+bleach==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,14 @@
+asgiref==3.4.1
+dj-pagination==2.5.0
 Django==3.0.8
 django-impersonate==1.5.1
-postmarkup==1.2.2
-Pygments==2.6.1
+importlib-metadata==4.6.1
 Markdown==3.3.4
 mypy-extensions==0.4.3
+postmarkup==1.2.2
+Pygments==2.6.1
+pymdown-extensions==8.2
+pytz==2021.1
+sqlparse==0.4.1
+typing-extensions==3.10.0.0
+zipp==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ Django==3.0.8
 django-impersonate==1.5.1
 postmarkup==1.2.2
 Pygments==2.6.1
+Markdown==3.3.4
+mypy-extensions==0.4.3

--- a/templates/base.html
+++ b/templates/base.html
@@ -148,14 +148,17 @@
 		{% endblock %}
 
 		<script>
-			MathJax = {
+			window.MathJax = {
 			  tex: {
 				inlineMath: [['\\(','\\)']],
+				displayMath: [['\\[','\\]']],
 				autoload: {
 				  color: [],
 				  colorV2: ['color']
 				},
-				packages: {'[+]': ['noerrors']}
+				packages: {'[+]': ['noerrors']},
+				processEscapes: true,
+				processEnvironments: true
 			  },
 			  options: {
 				ignoreHtmlClass: 'tex2jax_ignore',

--- a/templates/help/markdown.html
+++ b/templates/help/markdown.html
@@ -1,0 +1,26 @@
+{% extends "help/menu.html" %}
+
+{% load bbcode %}
+
+{% block head_title %}
+	Markdown -- Help
+{% endblock %}
+
+{% block tab %}
+<h3>Markdown</h3>
+
+{% bbcode %}
+[md]
+Aby używać Markdowna zamiast BBCode'a, na początku tekstu napisz `[md]`. 
+O składni Markdowna można przeczytać [tutaj](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf) (@mentions nie są obsługiwane).
+
+Aby z Markdowna użyć $\LaTeX$a:
+
+ - w linii: `$x + 2y$` lub `\( x + 2y \)` - \( x + 2y \) - w przypadku zapisu z dolarami niezbędny jest brak spacji
+ - w bloku: `$$ x + 2y $$` lub `\[ x + 2y \]` - koniecznie od nowej linii
+ 
+$$	x + 2y $$
+
+{% endbbcode %}
+
+{% endblock %}

--- a/templates/help/menu.html
+++ b/templates/help/menu.html
@@ -26,6 +26,10 @@
 		<a href="{% url 'help-latex' %}">{% icon 'text-width' %} LaTeX</a>
 	</li>
 
+	<li{% if tab == "markdown" %} class="active"{% endif %}>
+		<a href="{% url 'help-markdown' %}">{% icon 'align-left' %} Markdown</a>
+	</li>
+
 </ul>
 
 {% block tab %}

--- a/utils/markdown.py
+++ b/utils/markdown.py
@@ -16,10 +16,7 @@ extensions = [
 extension_configs = {
     "pymdownx.magiclink": {
         "repo_url_shortener": True,
-        "repo_url_shorthand": True,
-        "provider": "github",
-        "user": "facelessuser",
-        "repo": "pymdown-extensions",
+        "social_url_shortener": True,
     },
     "pymdownx.tilde": {"subscript": False},
     "pymdownx.emoji": {

--- a/utils/markdown.py
+++ b/utils/markdown.py
@@ -1,0 +1,45 @@
+from markdown import markdown
+from pymdownx import emoji
+
+extensions = [
+    "markdown.extensions.tables",
+    "pymdownx.magiclink",
+    "pymdownx.betterem",
+    "pymdownx.tilde",
+    "pymdownx.emoji",
+    "pymdownx.tasklist",
+    "pymdownx.superfences",
+    "pymdownx.saneheaders",
+    "pymdownx.arithmatex",
+]
+
+extension_configs = {
+    "pymdownx.magiclink": {
+        "repo_url_shortener": True,
+        "repo_url_shorthand": True,
+        "provider": "github",
+        "user": "facelessuser",
+        "repo": "pymdown-extensions",
+    },
+    "pymdownx.tilde": {"subscript": False},
+    "pymdownx.emoji": {
+        "emoji_index": emoji.gemoji,
+        "emoji_generator": emoji.to_png,
+        "alt": "short",
+        "options": {
+            "attributes": {"align": "absmiddle", "height": "20px", "width": "20px"},
+            "image_path": "https://github.githubassets.com/images/icons/emoji/unicode/",
+            "non_standard_image_path": "https://gitfhub.githubassets.com/images/icons/emoji/",
+        },
+    },
+    "pymdownx.arithmatex": {"generic": True},
+    "pymdownx.superfences": {"css_class": "code"},
+}
+
+
+def evaluate(text):
+    return (
+        '<div class="markdown bbcode">'
+        + markdown(text, extensions=extensions, extension_configs=extension_configs)
+        + "</div>"
+    )

--- a/utils/markdown.py
+++ b/utils/markdown.py
@@ -1,5 +1,6 @@
 from markdown import markdown
 from pymdownx import emoji
+from bleach import clean
 
 extensions = [
     "markdown.extensions.tables",
@@ -37,6 +38,6 @@ extension_configs = {
 def evaluate(text):
     return (
         '<div class="markdown bbcode">'
-        + markdown(text, extensions=extensions, extension_configs=extension_configs)
+        + markdown(clean(text), extensions=extensions, extension_configs=extension_configs)
         + "</div>"
     )

--- a/utils/markdown.py
+++ b/utils/markdown.py
@@ -34,10 +34,31 @@ extension_configs = {
     "pymdownx.superfences": {"css_class": "code"},
 }
 
+tags  = [
+    "h1", "h2", "h3", "h4", "h5", "h6",
+    "b", "i", "strong", "em", "tt",
+    "p", "br",
+    "span", "div", "blockquote", "code", "pre", "hr",
+    "ul", "ol", "li", "dd", "dt",
+    "img",
+    "a",
+    "sub", "sup",
+    "table", "thead", "tbody", "th", "td", "tr",
+]
+
+attributes = {
+    "*": ["id"],
+    "img": ["src", "alt", "title"],
+    "a": ["href", "alt", "title"],
+    "div": ["class"], "span": ["class"]
+}
+
+def sanitize(text):
+    return clean(text, tags=tags, attributes=attributes)
 
 def evaluate(text):
     return (
         '<div class="markdown bbcode">'
-        + markdown(clean(text), extensions=extensions, extension_configs=extension_configs)
+        + sanitize(markdown(text, extensions=extensions, extension_configs=extension_configs))
         + "</div>"
     )


### PR DESCRIPTION
Adds Markdown support to BBCode tag and fixes some dependency issues.

In order to use Markdown, start the text with [md]. The rest will render as Markdown instead of BBcode.